### PR TITLE
Fix links template for beta and stable

### DIFF
--- a/Casks/ferdium-beta.rb
+++ b/Casks/ferdium-beta.rb
@@ -1,5 +1,5 @@
 cask "ferdium-beta" do
-  arch = Hardware::CPU.intel? ? "" : "-arm64"
+  arch = Hardware::CPU.intel? ? "x64" : "arm64"
 
   version "6.0.0-beta.3"
 
@@ -9,7 +9,7 @@ cask "ferdium-beta" do
     sha256 "3923c2b264c664393f4f4f0a231769a9a6f00ba4be5fa0073edf30b7e0d44d98"
   end
 
-  url "https://github.com/ferdium/ferdium-app/releases/download/v#{version}/Ferdium-#{version}#{arch}.dmg",
+  url "https://github.com/ferdium/ferdium-app/releases/download/v#{version}/Ferdium-mac-#{version}-#{arch}.dmg",
       verified: "github.com/ferdium/ferdium-app/"
 
   name "Ferdium"

--- a/Casks/ferdium.rb
+++ b/Casks/ferdium.rb
@@ -1,5 +1,5 @@
 cask "ferdium" do
-  arch = Hardware::CPU.intel? ? "" : "-arm64"
+  arch = Hardware::CPU.intel? ? "x64" : "arm64"
 
   version "6.0.0"
 
@@ -9,7 +9,7 @@ cask "ferdium" do
     sha256 "ff64c6d110f29c657bf0cc52d9f41205a371c03b3f36b3a7535d31fa5f7e471a"
   end
 
-  url "https://github.com/ferdium/ferdium-app/releases/download/v#{version}/Ferdium-#{version}#{arch}.dmg",
+  url "https://github.com/ferdium/ferdium-app/releases/download/v#{version}/Ferdium-mac-#{version}-#{arch}.dmg",
       verified: "github.com/ferdium/ferdium-app/"
 
   name "Ferdium"


### PR DESCRIPTION
Following the change of asset names on `ferdium/ferdium-app`, we need to apply it to the beta and stable releases for it to work.