### PR TITLE
Revert "ferdium 6.2.7-nightly.13"

### DIFF
--- a/Casks/ferdium.rb
+++ b/Casks/ferdium.rb
@@ -1,9 +1,9 @@
 cask "ferdium" do
   arch arm: "arm64", intel: "x64"
 
-  version "6.2.7-nightly.13"
-  sha256 arm:   "49225f2bf536ba74483bca15b90cf13568a6bf101bafe5308f44229551577fab",
-         intel: "fa7d900227fd1d24eae2e36a1159f9502bb67ab5a5e4e4089cdb1e30b900690f"
+  version "6.2.6"
+  sha256 arm:   "f429ef7943c8de1a3de14244f826968a76ef530f76be5debc341f4e49c98f1d3",
+         intel: "a446bde14451524e7d23bb3a568fe6aba596925d8b687c2e4589880f35107358"
 
   url "https://github.com/ferdium/ferdium-app/releases/download/v#{version}/Ferdium-mac-#{version}-#{arch}.dmg",
       verified: "github.com/ferdium/ferdium-app/"


### PR DESCRIPTION
Reverts ferdium/homebrew-ferdium#162

I didn't notice that PR for releases are incorrectly created, so these need to be prepared by hand.